### PR TITLE
fix(timr): changed behaviour of finished to only emit finish

### DIFF
--- a/src/Timr.ts
+++ b/src/Timr.ts
@@ -56,8 +56,13 @@ class Timr extends EventEmitter {
     })
 
     if (this.currentTime <= 0) {
-      this.stop()
+      this.clear()
+
+      this.currentTime = this.startTime
+
       this.emit('finish', this)
+
+      this.status = Status.finished
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,5 +93,6 @@ export enum Status {
   started = 'started',
   paused = 'paused',
   stopped = 'stopped',
+  finished = 'finished',
   destroyed = 'destroyed'
 }

--- a/test/Timr.spec.js
+++ b/test/Timr.spec.js
@@ -357,7 +357,12 @@ describe('Timr Class', () => {
       const timer = new Timr(1).start()
       timer.finish((self) => {
         expect(self).toBe(timer)
-        done()
+
+        setTimeout(() => {
+          expect(self.getStatus()).toBe(Status.finished)
+          done()
+        })
+
       })
     })
 


### PR DESCRIPTION
Previous behaviour when a timer finished used this.stop() to clear the timers. This resulted in a
timer emitting stop AND finish when it had finished which is not the desirable behaviour.

A new "finished" status is also set when a timer has finished.

BREAKING CHANGE: When a timer has finished it no longer emits "onStop" and only emits "finish".

fix #21